### PR TITLE
Custom download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The package has been set up to fetch and run Phantom for MacOS (darwin) and
 Linux based platforms (as identified by nodejs), using the pre-built binaries
 from https://github.com/bprodoehl/phantomjs/releases/
 
+However it is possible to provide a custom download URl by setting the `PHANTOMJS2_DOWNLOAD_URL` environment variable.
+
 Running
 -------
 

--- a/install.js
+++ b/install.js
@@ -23,6 +23,8 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
+// allow to specify a completely custom download url
+var customDownloadUrl = process.env.PHANTOMJS2_DOWNLOAD_URL || false
 var url = process.platform === 'win32' ? 'https://github.com/gskachkov/phantomjs/releases/download/' : 'https://github.com/bprodoehl/phantomjs/releases/download/'
 var systemPrefix = process.platform === 'win32' ? '-x86' : ''
 var cdnUrl = process.env.PHANTOMJS_CDNURL || url
@@ -107,7 +109,10 @@ whichDeferred.promise
     tmpPath = findSuitableTempDirectory(conf)
 
     // Can't use a global version so start a download.
-    if (process.platform === 'linux' && process.arch === 'x64') {
+    
+    if (customDownloadUrl) {
+      downloadUrl = customDownloadUrl
+    } else if (process.platform === 'linux' && process.arch === 'x64') {
       downloadUrl += 'linux-x86_64.zip'
     } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
       downloadUrl += 'macosx.zip'


### PR DESCRIPTION
Works by setting `PHANTOMJS2_DOWNLOAD_URL`. I decided against detecting if the host is running Ubuntu in a suitable version and setting the download URL to `something...-u1404...zip`. According to the [previous naming scheme](https://bitbucket.org/ariya/phantomjs/downloads) it should actually be `something...linux..zip` and I expect this to continue as soon as PhantomJS 2 is stable.
