### PR TITLE
Update linux download url (linux-x86_64.zip-> 404)

### DIFF
--- a/install.js
+++ b/install.js
@@ -113,7 +113,7 @@ whichDeferred.promise
     if (customDownloadUrl) {
       downloadUrl = customDownloadUrl
     } else if (process.platform === 'linux' && process.arch === 'x64') {
-      downloadUrl += 'linux-x86_64.zip'
+      downloadUrl += 'u1404-x86_64.zip'
     } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
       downloadUrl += 'macosx.zip'
     } else if (process.platform === 'win32') {


### PR DESCRIPTION
Updated the download url for the linux distro to u1404-x86_64.zip since the releases page (https://github.com/bprodoehl/phantomjs/releases) has no other distros available and the current pattern (linux-x86_64.zip) will always fail.
