### PR TITLE
Bad version value prevents local phantom install

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -26,7 +26,7 @@ try {
  * The version of phantomjs installed by this package.
  * @type {number}
  */
-exports.version = '2.0.0-20141016'
+exports.version = '2.0.0 (development)'
 
 
 /**


### PR DESCRIPTION
This property is referred to by install.js as helper.version for comparison against the 'phantomjs.exe --version' result retrieved from
the copy(s) found in the system path. The version currently being downloaded by the app is '2.0.0 (development)', so currently if you
install the release version and just copy the downloaded phantomjs.exe into a folder in your path, when it finds it the install.js incorrectly
reports that it's the wrong version because it's expecting the output to be '2.0.0-20141016'. I personally think there needs to be a more
complicated evaluation rather than an exact match, so that any 2.x version would work, but this will suffice for now.
