### PR TITLE
Add ability to specify PHANTOMJS2_VERSION via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What this installer is really doing is just grabbing a particular "blessed" (by 
 
 The package has been set up to fetch and run Phantom for MacOS (darwin) and Linux based platforms (as identified by nodejs), using the pre-built binaries from https://github.com/bprodoehl/phantomjs/releases/
 
-However it is possible to provide a custom download URl by setting the `PHANTOMJS2_DOWNLOAD_URL` environment variable.
+However it is possible to provide a custom download URL by setting the `PHANTOMJS2_DOWNLOAD_URL` environment variable. If you want to specify a custom version, make sure to also specify `PHANTOMJS2_VERSION`.
 
 Running
 -------

--- a/install.js
+++ b/install.js
@@ -28,7 +28,8 @@ var customDownloadUrl = process.env.PHANTOMJS2_DOWNLOAD_URL || false
 var url = process.platform === 'win32' ? 'https://github.com/gskachkov/phantomjs/releases/download/' : 'https://github.com/bprodoehl/phantomjs/releases/download/'
 var systemPrefix = process.platform === 'win32' ? '-x86' : ''
 var cdnUrl = process.env.PHANTOMJS_CDNURL || url
-var downloadUrl = cdnUrl + helper.version + systemPrefix + '/phantomjs-' + helper.version + '-'
+var phantomVersion = process.env.PHANTOMJS2_VERSION || helper.version
+var downloadUrl = cdnUrl + phantomVersion + systemPrefix + '/phantomjs-' + phantomVersion + '-'
 
 var originalPath = process.env.PATH
 
@@ -88,7 +89,7 @@ whichDeferred.promise
   })
   .then(function (stdout) {
     var version = stdout.trim()
-    if (helper.version == version) {
+    if (phantomVersion == version) {
       writeLocationFile(phantomPath);
       console.log('PhantomJS is already installed at', phantomPath + '.')
       exit(0)
@@ -337,7 +338,7 @@ function copyIntoPlace(extractedPath, targetPath) {
     var files = fs.readdirSync(extractedPath)
     for (var i = 0; i < files.length; i++) {
       var file = path.join(extractedPath, files[i])
-      if (fs.statSync(file).isDirectory() && file.indexOf(helper.version) != -1) {
+      if (fs.statSync(file).isDirectory() && file.indexOf(phantomVersion) != -1) {
         console.log('Copying extracted folder', file, '->', targetPath)
         return kew.nfcall(ncp, file, targetPath)
       }


### PR DESCRIPTION
The PHANTOMJS2_DOWNLOAD_URL wasn't quite useful because you couldn't override the value in helper.version. This PR adds PHANTOMJS2_VERSION, which gives you what you need.
